### PR TITLE
Added markdown command

### DIFF
--- a/modules/formatting/cog.py
+++ b/modules/formatting/cog.py
@@ -1,11 +1,11 @@
 from discord.ext import commands
-from .formatting_tips import FormattingTips
+from .tip_formatter import TipFormatter
 
 
 class FormattingCog(commands.Cog, name="Formatting Tips"):
 	def __init__(self, bot):
 		self.bot = bot
-		self.tips = FormattingTips()
+		self.tips = TipFormatter()
 
 	@commands.command(name="markdown", aliases=["md"])
 	async def markdown(self, ctx, *args):

--- a/modules/formatting/cog.py
+++ b/modules/formatting/cog.py
@@ -26,7 +26,7 @@ class FormattingCog(commands.Cog, name="Formatting Tips"):
 			message = self.tips.all_markdown_tips()
 			await ctx.send(message)
 		else:
-			message = self.tips.individual_info(ctx, " ".join(args))
+			message = self.tips.individual_info(ctx, "".join(args))
 			await ctx.send(message)
 
 

--- a/modules/formatting/cog.py
+++ b/modules/formatting/cog.py
@@ -1,0 +1,23 @@
+from discord.ext import commands
+from .formatting_tips import FormattingTips
+
+
+class FormattingCog(commands.Cog, name="Formatting Tips"):
+	def __init__(self, bot):
+		self.bot = bot
+		self.tips = FormattingTips()
+
+	@commands.command(name="markdown")
+	async def markdown(self, ctx):
+		"""Replies with a summary of basic markdown supported by Discord."""
+		await ctx.send(self.tips.markdown_info())
+
+	@commands.command(name="codeblock")
+	async def codeblock(self, ctx):
+		"""Replies with a summary of how to format code with codeblocks."""
+		await ctx.send(self.tips.codeblock_info())
+
+
+# setup functions for bot
+def setup(bot):
+	bot.add_cog(FormattingCog(bot))

--- a/modules/formatting/cog.py
+++ b/modules/formatting/cog.py
@@ -7,15 +7,27 @@ class FormattingCog(commands.Cog, name="Formatting Tips"):
 		self.bot = bot
 		self.tips = FormattingTips()
 
-	@commands.command(name="markdown")
-	async def markdown(self, ctx):
-		"""Replies with a summary of basic markdown supported by Discord."""
-		await ctx.send(self.tips.markdown_info())
+	@commands.command(name="markdown", aliases=["md"])
+	async def markdown(self, ctx, *args):
+		"""
+		Command to display markdown tips for Discord messages.
 
-	@commands.command(name="codeblock")
-	async def codeblock(self, ctx):
-		"""Replies with a summary of how to format code with codeblocks."""
-		await ctx.send(self.tips.codeblock_info())
+		Usage:
+		```
+		++md [format]
+		```
+		Arguments:
+
+			> **format** (optional): The format to display information about (ex. "bold", "italics", "codeblock", ...)
+
+		If no argument is specified, all markdown tips will be displayed
+		"""
+		if len(args) == 0:
+			message = self.tips.all_markdown_tips()
+			await ctx.send(message)
+		else:
+			message = self.tips.individual_info(ctx, " ".join(args))
+			await ctx.send(message)
 
 
 # setup functions for bot

--- a/modules/formatting/cog.py
+++ b/modules/formatting/cog.py
@@ -20,7 +20,7 @@ class FormattingCog(commands.Cog, name="Formatting Tips"):
 
 			> **format** (optional): The format to display information about (ex. "bold", "italics", "codeblock", ...)
 
-		If no argument is specified, all markdown tips will be displayed
+		If no argument is specified, all markdown tips will be displayed.
 		"""
 		if len(args) == 0:
 			message = self.tips.all_markdown_tips()

--- a/modules/formatting/formatting_tip.py
+++ b/modules/formatting/formatting_tip.py
@@ -1,0 +1,4 @@
+class Tip:
+	def __init__(self, preview: str, escaped: str):
+		self.preview = preview
+		self.escaped = escaped

--- a/modules/formatting/formatting_tips.py
+++ b/modules/formatting/formatting_tips.py
@@ -53,10 +53,10 @@ class FormattingTips:
 				"Copy the snippet into a message replacing the text with your own."
 			)
 
-	def __normalize(self, ctx: commands.Context, format: str):
+	def __normalize(self, ctx: commands.Context, format: str) -> str:
 		"""normalize format to match format keys"""
 		# strip whitespace and convert to lowercase
-		normal_format = format.lower().replace(" ", "")
+		normal_format = format.lower()
 		# check if inputted format is recognized
 		if normal_format in self.formats:
 			return normal_format

--- a/modules/formatting/formatting_tips.py
+++ b/modules/formatting/formatting_tips.py
@@ -22,7 +22,10 @@ class FormattingTips:
 		self.aliases = {
 			"italic": "italics",
 			"inlinecode": "inline",
+			"spoilers": "spoiler",
+			"underlines": "underline",
 			"code": "codeblock",
+			"codeblocks": "codeblock",
 			"codesnippet": "codeblock",
 			"snippet": "codeblock",
 			"strike": "strikethrough",

--- a/modules/formatting/formatting_tips.py
+++ b/modules/formatting/formatting_tips.py
@@ -1,0 +1,10 @@
+class FormattingTips:
+	def markdown_info(self):
+		return (
+			"test"
+		)
+
+	def codeblock_info(self):
+		return (
+			"test"
+		)

--- a/modules/formatting/formatting_tips.py
+++ b/modules/formatting/formatting_tips.py
@@ -74,10 +74,8 @@ class FormattingTips:
 		(_, escaped) = self.formats["codeblock"]
 		return (
 			"Did you know you can format your code with a monospace font and syntax"
-			" highlighting on Discord?\n\n"
-			f"{blockquote(escaped)}\n\n"
-			"Copy the snippet above"
-			" into a message and insert your code in the middle. You can also change"
-			" the syntax highlighting language by replacing `cpp` with another"
+			f" highlighting on Discord?\n\n{blockquote(escaped)}\n\nCopy the snippet"
+			" above into a message and insert your code in the middle. You can also"
+			" change the syntax highlighting language by replacing `cpp` with another"
 			" language, for example, `js`, `py`, or `java`."
 		)

--- a/modules/formatting/formatting_tips.py
+++ b/modules/formatting/formatting_tips.py
@@ -55,14 +55,14 @@ class FormattingTips:
 
 	def __normalize(self, ctx: commands.Context, format: str) -> str:
 		"""normalize format to match format keys"""
-		# strip whitespace and convert to lowercase
-		normal_format = format.lower()
+		# convert to lowercase
+		lower_format = format.lower()
 		# check if inputted format is recognized
-		if normal_format in self.formats:
-			return normal_format
+		if lower_format in self.formats:
+			return lower_format
 		# check for aliases
-		elif normal_format in self.aliases:
-			return self.aliases[normal_format]
+		elif lower_format in self.aliases:
+			return self.aliases[lower_format]
 		# format is not recognized
 		else:
 			raise FriendlyError(

--- a/modules/formatting/tip_formatter.py
+++ b/modules/formatting/tip_formatter.py
@@ -1,19 +1,20 @@
 from utils.utils import blockquote
 from modules.error.friendly_error import FriendlyError
 from discord.ext import commands
+from .formatting_tip import Tip
 
 
-class FormattingTips:
+class TipFormatter:
 	def __init__(self):
 		# maps format name to pair containing preview markdown and escaped markdown
 		self.formats = {
-			"italics": ("*italics*", "\*italics* or \_italics_"),
-			"bold": ("**bold text**", "\**bold text**"),
-			"underline": ("__underline__", "\__underline__"),
-			"strikethrough": ("~~strikethrough~~", "\~~strikethrough~~"),
-			"spoiler": ("||spoiler|| (click to reveal)", "\||spoiler||"),
-			"inline": ("`inline code`", "\`inline code`"),
-			"codeblock": (
+			"italics": Tip("*italics*", "\*italics* or \_italics_"),
+			"bold": Tip("**bold text**", "\**bold text**"),
+			"underline": Tip("__underline__", "\__underline__"),
+			"strikethrough": Tip("~~strikethrough~~", "\~~strikethrough~~"),
+			"spoiler": Tip("||spoiler|| (click to reveal)", "\||spoiler||"),
+			"inline": Tip("`inline code`", "\`inline code`"),
+			"codeblock": Tip(
 				'```cpp\ncout << "Code Block";\n```',
 				'\```cpp\n// replace this with your code\ncout << "Code Block";\n```',
 			),
@@ -35,23 +36,19 @@ class FormattingTips:
 		"""return a list of all markdown tips"""
 		message = "**__Markdown Tips__**\n\n"
 		for format in self.formats:
-			(preview, escaped) = self.formats[format]
-			message += f"{preview}\n"
-			message += f"{blockquote(escaped)}\n\n"
+			tip = self.formats[format]
+			message += f"{tip.preview}\n"
+			message += f"{blockquote(tip.escaped)}\n\n"
 		return message
 
 	def individual_info(self, ctx: commands.Context, format: str) -> str:
 		"""return info for given format"""
-		normalized = self.__normalize(ctx, format)
-		if normalized == "codeblock":
-			return self.__codeblock_info()
-		else:
-			(preview, escaped) = self.formats[normalized]
-			return (
-				f"Did you know you can format your message with {preview}?\n\n"
-				f"{blockquote(escaped)}\n\n"
-				"Copy the snippet into a message replacing the text with your own."
-			)
+		format = self.__normalize(ctx, format)
+		tip = self.formats[format]
+		header_text = self.__header(format, tip)
+		how_to = blockquote(tip.escaped)
+		footer_text = self.__footer(format)
+		return f"{header_text}\n\n{how_to}\n\n{footer_text}"
 
 	def __normalize(self, ctx: commands.Context, format: str) -> str:
 		"""normalize format to match format keys"""
@@ -69,13 +66,22 @@ class FormattingTips:
 				f"'{format}' is not a recognized format.", ctx.channel, ctx.author
 			)
 
-	def __codeblock_info(self) -> str:
-		"""Returns info about using codeblocks."""
-		(_, escaped) = self.formats["codeblock"]
-		return (
-			"Did you know you can format your code with a monospace font and syntax"
-			f" highlighting on Discord?\n\n{blockquote(escaped)}\n\nCopy the snippet"
-			" above into a message and insert your code in the middle. You can also"
-			" change the syntax highlighting language by replacing `cpp` with another"
-			" language, for example, `js`, `py`, or `java`."
-		)
+	def __header(self, format: str, tip: Tip) -> str:
+		if format == "codeblock":
+			return (
+				"Did you know you can format your code with a monospace font and syntax"
+				" highlighting on Discord?"
+			)
+		else:
+			return f"Did you know you can format your message with {tip.preview}?"
+
+	def __footer(self, format: str) -> str:
+		if format == "codeblock":
+			return (
+				"Copy the snippet above into a message and insert your code in the"
+				" middle. You can also change the syntax highlighting language by"
+				" replacing `cpp` with another language, for example, `js`, `py`, or"
+				" `java`."
+			)
+		else:
+			return "Copy the snippet into a message replacing the text with your own."

--- a/modules/search/cog.py
+++ b/modules/search/cog.py
@@ -11,7 +11,7 @@ import modules.search.search_functions as sf
 import config
 
 
-class Search(commands.Cog):
+class SearchCog(commands.Cog, name="Search"):
 	def __init__(self, bot):
 		self.bot = bot
 		self.last_paragraph = {}
@@ -34,11 +34,13 @@ class Search(commands.Cog):
 		async with ctx.typing():
 			links = search(searched_string, num_results=1)
 			wiki, wiki_link = sf.get_wiki(searched_string)
-			wiki_intro = sf.get_wiki_intro(wiki, wiki_link, self.last_paragraph, channel_id)
+			wiki_intro = sf.get_wiki_intro(
+				wiki, wiki_link, self.last_paragraph, channel_id
+			)
 
 		await sf.send_message(ctx, searched_string, wiki_intro, links)
 
 
 # setup functions for bot
 def setup(bot):
-	bot.add_cog(Search(bot))
+	bot.add_cog(SearchCog(bot))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -26,3 +26,8 @@ def get_id(label: str) -> int:
 def remove_tabs(string: str) -> str:
 	"""removed up to limit_per_line (default infinitely many) tabs from the beginning of each line of string"""
 	return re.sub(r"\n\t*", "\n", string).strip()
+
+
+def blockquote(string: str) -> str:
+	"""Add blockquotes to a string"""
+	return re.sub(r"(^|\n)", r"\1> ", string)


### PR DESCRIPTION
Closes #43

Command to display markdown tips for Discord messages.

Usage:
```
++md [format]
```

Arguments:

> **format** (optional): The format to display information about (ex. "bold", "italics", "codeblock", ...)

If no argument is specified, all markdown tips will be displayed.