### PR TITLE
Added more separators and error messages

### DIFF
--- a/modules/calendar/calendar.py
+++ b/modules/calendar/calendar.py
@@ -76,15 +76,17 @@ class Calendar:
 		# parse start date
 		start_date = dateparser.parse(start, settings=self.dateparser_settings)
 		# parse end date
-		if not end:
+		if end is None:
 			end_date = start_date
+		if start_date is None:
+			raise ValueError(f'Start date "{start}" could not be parsed.')
 		else:
 			end_date = dateparser.parse(
 				end, settings={**self.dateparser_settings, "RELATIVE_BASE": start_date}
 			)
 		# check if dates did not parse as None
-		if not start_date or not end_date:
-			raise ValueError("Dates could not be parsed.")
+		if end_date is None:
+			raise ValueError(f'End date "{end}" could not be parsed.')
 		# if the end date is before the start date, update the date to starting date
 		if end_date < start_date:
 			raise ValueError("End date must be before start date.")

--- a/modules/calendar/calendar.py
+++ b/modules/calendar/calendar.py
@@ -75,16 +75,18 @@ class Calendar:
 		and optionally, the end time, location and description."""
 		# parse start date
 		start_date = dateparser.parse(start, settings=self.dateparser_settings)
+		# check start date
+		if start_date is None:
+			raise ValueError(f'Start date "{start}" could not be parsed.')
 		# parse end date
-		if end is not None and start_date is not None:
+		if end is not None:
 			end_date = dateparser.parse(
 				end, settings={**self.dateparser_settings, "RELATIVE_BASE": start_date}
 			)
-		elif start_date is None:
-			raise ValueError(f'Start date "{start}" could not be parsed.')
 		else:
+			# no end date was specified
 			end_date = start_date
-		# check if dates did not parse as None
+		# check end date
 		if end_date is None:
 			raise ValueError(f'End date "{end}" could not be parsed.')
 		# if the end date is before the start date, update the date to starting date

--- a/modules/calendar/calendar.py
+++ b/modules/calendar/calendar.py
@@ -76,14 +76,14 @@ class Calendar:
 		# parse start date
 		start_date = dateparser.parse(start, settings=self.dateparser_settings)
 		# parse end date
-		if end is None:
-			end_date = start_date
-		if start_date is None:
-			raise ValueError(f'Start date "{start}" could not be parsed.')
-		else:
+		if end is not None and start_date is not None:
 			end_date = dateparser.parse(
 				end, settings={**self.dateparser_settings, "RELATIVE_BASE": start_date}
 			)
+		elif start_date is None:
+			raise ValueError(f'Start date "{start}" could not be parsed.')
+		else:
+			end_date = start_date
 		# check if dates did not parse as None
 		if end_date is None:
 			raise ValueError(f'End date "{end}" could not be parsed.')

--- a/modules/calendar/calendar_embedder.py
+++ b/modules/calendar/calendar_embedder.py
@@ -77,8 +77,14 @@ class CalendarEmbedder:
 		if base and date.strftime("%d %b") == base.strftime("%d %b"):
 			# return the time (format: '3:45 AM')
 			return date.strftime("%I:%M %p").lstrip("0")
-		# return the date and time (format: 'Sun 1 Feb 3:45 AM')
-		return date.strftime("%a %d %b %I:%M %p").replace(" 0", " ")
+		# date is in the current year
+		if date.year == datetime.now().year:
+			# return the date, month, and time (format: 'Sun 1 Feb 3:45 AM')
+			return date.strftime("%a %d %b %I:%M %p").replace(" 0", " ")
+		# date is in a different year
+		else:
+			# return the date, month, year, and time (format: 'Sun 1 Feb 2020 3:45 AM')
+			return date.strftime("%a %d %b %Y %I:%M %p").replace(" 0", " ")
 
 	def __get_footer_text(self):
 		"""Return text about timezone to display at end of embeds with dates"""


### PR DESCRIPTION
A few small changes to make things easier.

* Added more valid separators to allow:

`++events.add Calculus 2 Review Class at 5pm for 1 hour`

`++events.add Calculus 2 Review Class on February 18 from 14:30 until 17:00`

`++events.add Calculus 2 Review Class on February 18 at 14:30-17:00`

* Raises date parsing errors as friendly errors to make fixing problems easier.

* Years will appear in outputs when the year is not the current year:

Example:
```
Event in 2021
Thu 18 Feb 2:30 PM - 5:00 PM

Event in 2022
Sun 6 Feb 2022 12:00 AM - 12:00 AM
```