### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This bot was created by the contribution of the following members. If you would 
 
 ## Issues and Feature Requests
 
-If you'd like a new feature added to the bot, or you have discovered some misbehavior by it, please feel free to open an issue detailing it in the [GitHub issues tab](https://https://github.com/DenverCoder1/jct-discord-bot/issues).
+If you'd like a new feature added to the bot, or you have discovered some misbehavior by it, please feel free to open an issue detailing it in the [GitHub issues tab](https://github.com/DenverCoder1/jct-discord-bot/issues).
 
 ## Features
 


### PR DESCRIPTION
Fixed issue in line 38 where the link to the github issues tab had "https://" twice therefore causing a server IP error. 
Changed (https://https://github.com/DenverCoder1/jct-discord-bot/issues) to (https://github.com/DenverCoder1/jct-discord-bot/issues)