### PR TITLE
Fix updating events with only a start time

### DIFF
--- a/modules/calendar/calendar_service.py
+++ b/modules/calendar/calendar_service.py
@@ -202,8 +202,8 @@ class CalendarService:
 		}
 		# check that new time range is valid
 		new_event = Event(event_details)
-		new_start_date = new_event.start()
-		new_end_date = new_event.end()
+		new_start_date = new_event.start().replace(tzinfo=None)
+		new_end_date = new_event.end().replace(tzinfo=None)
 		if new_end_date < new_start_date:
 			raise ValueError("The start time must come before the end time.")
 		# update the event


### PR DESCRIPTION
Replace tzinfo when comparing time range. Avoids `can't compare offset-naive and offset-aware datetimes` when only a start time is specified when updating an event