### PR TITLE
Fix calendar skipping events and calendar update breaking links

### DIFF
--- a/modules/calendar/calendar_embedder.py
+++ b/modules/calendar/calendar_embedder.py
@@ -1,11 +1,11 @@
 from . import html_parser
 from discord.ext import commands
-from utils.utils import one, wait_for_reaction
+from utils.utils import one, peek, is_empty, wait_for_reaction
 from discord_slash.context import SlashContext
 from modules.error.friendly_error import FriendlyError
 from .calendar import Calendar
 from .event import Event
-from typing import Iterable, Dict, Optional, Sequence
+from typing import Generator, Dict, Optional, Sequence, Tuple
 import discord
 
 
@@ -32,38 +32,42 @@ class CalendarEmbedder:
 	async def embed_event_pages(
 		self,
 		ctx: SlashContext,
-		events: Sequence[Event],
+		events_list: Sequence[Event],
 		query: str,
 		results_per_page: int,
 		calendar: Calendar,
 	):
 		"""Embed page of events and wait for reactions to continue to new pages"""
+		# generator for events
+		events = (event for event in events_list)
 		# set start index
-		page_num = 1 if len(events) > results_per_page else None
+		page_num = 1 if len(events_list) > results_per_page else None
 		while True:
 			try:
-				# first event to display
-				start = (page_num - 1) * results_per_page if page_num else 0
 				# create embed
-				embed = self.embed_event_list(
+				embed, events = self.embed_event_list(
 					title=f"📅 Upcoming Events for {calendar.name}",
-					events=events[start : start + results_per_page],
+					events=events,
 					calendar=calendar,
 					description=f'Showing results for "{query}"' if query else "",
 					page_num=page_num,
+					max_results=results_per_page,
 				)
 				sender = ctx.send if ctx.message is None else ctx.message.edit
 				await sender(embed=embed)
 				# if only one page, break out of loop
 				if not page_num:
 					break
-				# set emoji and page based on if no more events
-				if start + results_per_page < len(events):
+				# set emoji and page based on whether there are more events
+				empty, events = is_empty(events)
+				if not empty:
 					next_emoji = "⏬"
 					page_num += 1
 				else:
 					next_emoji = "⤴️"
 					page_num = 1
+					# reset the generator
+					events = (event for event in events_list)
 				# wait for author to respond to go to next page
 				await wait_for_reaction(
 					bot=self.bot,
@@ -95,9 +99,9 @@ class CalendarEmbedder:
 		if len(events) == 1:
 			return one(events)
 		# multiple events found
-		embed = self.embed_event_list(
+		embed, _ = self.embed_event_list(
 			title=f"⚠ Multiple events were found.",
-			events=events,
+			events=(event for event in events),
 			calendar=calendar,
 			description=(
 				f"Please specify which event you would like to {action}."
@@ -120,19 +124,21 @@ class CalendarEmbedder:
 	def embed_event_list(
 		self,
 		title: str,
-		events: Iterable[Event],
+		events: Generator[Event, None, None],
 		calendar: Calendar,
 		description: str = "",
 		colour: discord.Colour = discord.Colour.blue(),
 		enumeration: Sequence[str] = (),
 		page_num: Optional[int] = None,
-	) -> discord.Embed:
+		max_results: int = 10,
+	) -> Tuple[discord.Embed, Generator[Event, None, None]]:
 		"""Generates an embed with event summaries, links, and dates for each event in the given list
 
 		Arguments:
 
 		:param title: :class:`str` the title to display at the top
-		:param events: :class:`Iterable[Event]` the events to display
+		:param events: :class:`Generator[Event, None, None]` the events to display
+		:param calendar: :class:`Calendar` the calendar the events are from
 		:param description: :class:`Optional[str]` the description to embed below the title
 		:param colour: :class:`Optional[discord.Colour]` the embed colour
 		:param enumeration: :class:`Optional[Iterable[str]]` list of emojis to display alongside events (for reaction choices)
@@ -142,11 +148,18 @@ class CalendarEmbedder:
 		embed.description = "" if description == "" else f"{description}\n"
 		# get calendar links
 		links = self.__calendar_links(calendar)
-		if not events:
-			embed.description += "No events found"
+		# check if generator is empty
+		empty, events = is_empty(events)
+		if empty:
+			embed.description += "No events found.\n"
 		else:
 			# add events to embed
-			for i, event in enumerate(events):
+			for i in range(max_results):
+				event, events = peek(events)
+				# if event is None, no more events
+				if not event:
+					break
+				# build event description
 				event_description = "\n"
 				# add enumeration emoji if available
 				if i < len(enumeration):
@@ -158,11 +171,13 @@ class CalendarEmbedder:
 					break
 				# add event to embed
 				embed.description += event_description
+				# consume event
+				next(events)
 		# add links for viewing and editing on Google Calendar
 		embed.description += links
 		# add page number and timezone info
 		embed.set_footer(text=self.__footer_text(page_num=page_num))
-		return embed
+		return embed, events
 
 	def embed_links(
 		self,

--- a/modules/calendar/calendar_embedder.py
+++ b/modules/calendar/calendar_embedder.py
@@ -148,24 +148,28 @@ class CalendarEmbedder:
 		:param description: :class:`Optional[str]` the description to embed below the title
 		:param colour: :class:`Optional[discord.Colour]` the embed colour
 		:param enumeration: :class:`Optional[Iterable[str]]` list of emojis to display alongside events (for reaction choices)
+		:param page_num: :class:`Optional[int]` page number to display in the footer
+		:param max_results: :class:`int` maximum results to display in the list
 		"""
 		embed = discord.Embed(title=title, colour=colour)
 		# get calendar links
 		links = self.__calendar_links(calendar)
+		# limit max results to the number of emojis in the enumeration
+		max_results = min(max_results, len(enumeration)) if enumeration else max_results
 		# set initial description if available
 		embed.description = f"{description}\n" if description else ""
 		# check if events peekable is empty
 		embed.description += "No events found.\n" if not events else ""
+		# create iterator for enumeration
+		enumerator = iter(enumeration)
 		# add events to embed
-		for i in range(max_results):
-			next_event = events.peek(None)
+		for _ in range(max_results):
+			event = events.peek(None)
 			# if event is None, no more events
-			if not next_event:
+			if not event:
 				break
-			# add enumeration emoji if available
-			event_details = f"\n{enumeration[i]} " if i < len(enumeration) else "\n"
-			# add the event details
-			event_details += self.__format_event(next_event)
+			# get event details and add enumeration emoji if available
+			event_details = f"\n{next(enumerator, '')} {self.__format_event(event)}"
 			# make sure embed doesn't exceed max length
 			if len(embed.description + event_details + links) > self.max_length:
 				break

--- a/modules/calendar/calendar_embedder.py
+++ b/modules/calendar/calendar_embedder.py
@@ -99,7 +99,7 @@ class CalendarEmbedder:
 		if len(events) == 1:
 			return one(events)
 		# multiple events found
-		embed, _ = self.embed_event_list(
+		embed, generator = self.embed_event_list(
 			title=f"⚠ Multiple events were found.",
 			events=(event for event in events),
 			calendar=calendar,
@@ -111,11 +111,14 @@ class CalendarEmbedder:
 			enumeration=self.number_emoji,
 		)
 		await ctx.send(embed=embed)
+		# get the number of events that were displayed
+		next_event = next(generator, None)
+		num_events = events.index(next_event) if next_event else len(events)
 		# ask user to pick an event with emojis
 		selection_index = await wait_for_reaction(
 			bot=self.bot,
 			message=ctx.message,
-			emoji_list=self.number_emoji[: len(events)],
+			emoji_list=self.number_emoji[:num_events],
 			allowed_users=[ctx.author],
 		)
 		# get the event selected by the user

--- a/modules/calendar/calendar_service.py
+++ b/modules/calendar/calendar_service.py
@@ -167,7 +167,7 @@ class CalendarService:
 		# check if event is all day
 		all_day = (
 			new_start_date.time() == datetime.min.time()
-			and new_end_date.time() == new_end_date.min.time()
+			and new_end_date.time() == datetime.min.time()
 			and new_start_date != new_end_date
 		)
 		# create request body

--- a/modules/calendar/calendar_service.py
+++ b/modules/calendar/calendar_service.py
@@ -168,10 +168,8 @@ class CalendarService:
 		event_details = {
 			"summary": new_summary or event.title,
 			"location": new_location or event.location or "",
-			"description": (
-				html_parser.md_links_to_html(new_description)
-				if new_description is not None
-				else event.description or ""
+			"description": html_parser.md_links_to_html(
+				new_description or event.description or ""
 			),
 			"start": {
 				"timeZone": self.timezone,

--- a/modules/calendar/calendar_service.py
+++ b/modules/calendar/calendar_service.py
@@ -164,6 +164,12 @@ class CalendarService:
 		# check that new time range is valid
 		if new_end_date < new_start_date:
 			raise ValueError("The start time must come before the end time.")
+		# check if event is all day
+		all_day = (
+			new_start_date.time() == datetime.min.time()
+			and new_end_date.time() == new_end_date.min.time()
+			and new_start_date != new_end_date
+		)
 		# create request body
 		event_details = {
 			"summary": new_summary or event.title,
@@ -171,14 +177,22 @@ class CalendarService:
 			"description": html_parser.md_links_to_html(
 				new_description or event.description or ""
 			),
-			"start": {
-				"timeZone": self.timezone,
-				"dateTime": new_start_date.isoformat("T", "seconds"),
-			},
-			"end": {
-				"timeZone": self.timezone,
-				"dateTime": new_end_date.isoformat("T", "seconds"),
-			},
+			"start": (
+				{
+					"dateTime": new_start_date.isoformat("T", "seconds"),
+					"timeZone": self.timezone,
+				}
+				if not all_day
+				else {"date": new_start_date.date().isoformat()}
+			),
+			"end": (
+				{
+					"dateTime": new_end_date.isoformat("T", "seconds"),
+					"timeZone": self.timezone,
+				}
+				if not all_day
+				else {"date": new_end_date.date().isoformat()}
+			),
 		}
 		# update the event
 		updated_event = (

--- a/modules/calendar/cog.py
+++ b/modules/calendar/cog.py
@@ -273,8 +273,8 @@ class CalendarCog(commands.Cog):
 		title: Optional[str] = None,
 		start: Optional[str] = None,
 		end: Optional[str] = None,
-		description=None,
-		location=None,
+		description: Optional[str] = None,
+		location: Optional[str] = None,
 		class_name: Optional[int] = None,
 	):
 		await ctx.defer()
@@ -289,17 +289,17 @@ class CalendarCog(commands.Cog):
 			ctx, events, calendar, query, "update"
 		)
 		# replace channel mentions and variables
-		if title is not None:
+		if title:
 			title = course_mentions.replace_channel_mentions(title).replace(
 				"${title}", event_to_update.title
 			)
-		if description is not None:
+		if description:
 			description = (
 				course_mentions.replace_channel_mentions(description)
 				.replace("${description}", event_to_update.description or "")
 				.replace("\\n", "\n")
 			)
-		if location is not None:
+		if location:
 			location = course_mentions.replace_channel_mentions(location).replace(
 				"${location}", event_to_update.location or ""
 			)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ dateparser==1.0.0
 pyluach==1.2.1
 fuzzywuzzy==0.18.0
 python-Levenshtein==0.12.2
+more-itertools==8.7.0

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -82,10 +82,10 @@ def parse_date(
 	# make times PM if time is early in the day, base is PM, and no indication that AM was specified
 	if (
 		date
-		and date.hour < 8
-		and base.hour >= 12
-		and not "am" in date_str.lower()
-		and not "T" in date_str
+		and date.hour < 8  # hour is before 8:00
+		and base.hour >= 12  # relative base is PM
+		and not "am" in date_str.lower()  # am is not specified
+		and not re.match(r"^2\d{3}-[01]\d-[0-3]\d\S*$", date_str)  # not in iso format
 	):
 		date += timedelta(hours=12)
 	# return the datetime object

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -5,7 +5,7 @@ import dateparser
 import asyncio
 import discord
 from datetime import datetime, timedelta
-from typing import Any, Collection, Dict, Generator, Iterable, Optional, Sequence, Tuple
+from typing import Any, Collection, Dict, Iterable, Optional, Sequence
 from discord.errors import NotFound
 from discord.ext import commands
 from modules.error.friendly_error import FriendlyError
@@ -184,26 +184,3 @@ async def wait_for_reaction(
 def one(iterable: Iterable):
 	"""Returns a single element from an iterable or raises StopIteration if it was empty."""
 	return next(iter(iterable))
-
-
-def peek(generator: Generator, default: Any = None) -> Tuple[Any, Generator]:
-	"""Returns the next item and a generator which matches the one passed"""
-
-	def new_generator(first: Any) -> Generator[Any, None, None]:
-		"""yield the item removed and then the rest of the items"""
-		yield first
-		yield from generator
-
-	try:
-		next_item = next(generator)
-		# return the extracted item and the original generator
-		return next_item, new_generator(next_item)
-	except StopIteration:
-		# return default and empty generator if generator was empty
-		return default, (_ for _ in [])
-
-
-def is_empty(generator: Generator) -> Tuple[Any, Generator]:
-	"""Returns True if generator is empty and a generator that matches the one passed"""
-	next_item, generator = peek(generator)
-	return next_item is None, generator


### PR DESCRIPTION
Fixes #154 (Events are collected from a generator and pages can be any size up to the max)

Fixes #158 (If no description is provided to `/calendar update`, the description will stay as HTML and not change to Markdown.)

Event list won't show more events than there are enumeration emoji

All-day events will no longer get shifted to 12pm when updating

When updating events to start and end at midnight, they will be saved as all-day events.