### PR TITLE
Bump googlesearch-python and bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 discord.py==1.7.2
 discord-py-slash-command==1.2.0
 python-dotenv==0.17.1
-googlesearch-python==2020.0.2
-beautifulsoup4==4.9.1
+googlesearch-python==1.0.1
+beautifulsoup4==4.9.3
 psycopg2-binary==2.8.6
 google-api-python-client==2.7.0
 google-auth-httplib2==0.1.0


### PR DESCRIPTION
googlesearch-python released a new version 1.0.1 which depends on bs4 version 4.9.3

Dependabot won't be able to fix this since they rewrote their version numbers (2020.0.2 --> 1.0.1)