### PR TITLE
Bump slash to v2, changed param names with connectors

### DIFF
--- a/modules/calendar/cog.py
+++ b/modules/calendar/cog.py
@@ -49,10 +49,11 @@ class CalendarCog(commands.Cog):
 				],
 			),
 		],
+		connector={"class_name": "group_id"},
 	)
-	async def calendar_links(self, ctx: SlashContext, class_name: Optional[int] = None):
+	async def calendar_links(self, ctx: SlashContext, group_id: Optional[int] = None):
 		# get calendar from selected class_role or author
-		calendar = Calendar.get_calendar(ctx, self.groups, class_name)
+		calendar = Calendar.get_calendar(ctx, self.groups, group_id)
 		# fetch links for calendar
 		links = self.service.get_links(calendar)
 		embed = self.embedder.embed_links(
@@ -94,17 +95,18 @@ class CalendarCog(commands.Cog):
 				],
 			),
 		],
+		connector={"class_name": "group_id"},
 	)
 	async def events(
 		self,
 		ctx: SlashContext,
 		query: str = "",
 		results_per_page: int = 5,
-		class_name: Optional[int] = None,
+		group_id: Optional[int] = None,
 	):
 		await ctx.defer()
 		# get calendar from selected class_role or author
-		calendar = Calendar.get_calendar(ctx, self.groups, class_name)
+		calendar = Calendar.get_calendar(ctx, self.groups, group_id)
 		# convert channel mentions to full names
 		full_query = course_mentions.replace_channel_mentions(query)
 		# fetch upcoming events
@@ -168,6 +170,7 @@ class CalendarCog(commands.Cog):
 				],
 			),
 		],
+		connector={"class_name": "group_id"},
 	)
 	async def event_add(
 		self,
@@ -177,7 +180,7 @@ class CalendarCog(commands.Cog):
 		end: Optional[str] = None,
 		description: str = "",
 		location: str = "",
-		class_name: Optional[int] = None,
+		group_id: Optional[int] = None,
 	):
 		await ctx.defer()
 		# replace channel mentions with course names
@@ -185,7 +188,7 @@ class CalendarCog(commands.Cog):
 		description = course_mentions.replace_channel_mentions(description)
 		location = course_mentions.replace_channel_mentions(location)
 		# get calendar from selected class_role or author
-		calendar = Calendar.get_calendar(ctx, self.groups, class_name)
+		calendar = Calendar.get_calendar(ctx, self.groups, group_id)
 		try:
 			event = self.service.add_event(
 				calendar.id, title, start, end, description, location
@@ -265,6 +268,7 @@ class CalendarCog(commands.Cog):
 				],
 			),
 		],
+		connector={"class_name": "group_id"},
 	)
 	async def event_update(
 		self,
@@ -275,13 +279,13 @@ class CalendarCog(commands.Cog):
 		end: Optional[str] = None,
 		description: Optional[str] = None,
 		location: Optional[str] = None,
-		class_name: Optional[int] = None,
+		group_id: Optional[int] = None,
 	):
 		await ctx.defer()
 		# replace channel mentions with course names
 		query = course_mentions.replace_channel_mentions(query)
 		# get calendar from selected class_role or author
-		calendar = Calendar.get_calendar(ctx, self.groups, class_name)
+		calendar = Calendar.get_calendar(ctx, self.groups, group_id)
 		# get a list of upcoming events
 		events = self.service.fetch_upcoming(calendar.id, query)
 		# get event to update
@@ -349,18 +353,19 @@ class CalendarCog(commands.Cog):
 				],
 			),
 		],
+		connector={"class_name": "group_id"},
 	)
 	async def event_delete(
 		self,
 		ctx: SlashContext,
 		query: str,
-		class_name: Optional[int] = None,
+		group_id: Optional[int] = None,
 	):
 		await ctx.defer()
 		# replace channel mentions with course names
 		query = course_mentions.replace_channel_mentions(query)
 		# get calendar from selected class_role or author
-		calendar = Calendar.get_calendar(ctx, self.groups, class_name)
+		calendar = Calendar.get_calendar(ctx, self.groups, group_id)
 		# fetch upcoming events
 		events = self.service.fetch_upcoming(calendar.id, query)
 		# get event to delete
@@ -404,16 +409,17 @@ class CalendarCog(commands.Cog):
 				],
 			),
 		],
+		connector={"class_name": "group_id"},
 	)
 	async def calendar_grant(
 		self,
 		ctx: SlashContext,
 		email: str,
-		class_name: Optional[int] = None,
+		group_id: Optional[int] = None,
 	):
 		await ctx.defer(hidden=True)
 		# get calendar from selected class_role or author
-		calendar = Calendar.get_calendar(ctx, self.groups, class_name)
+		calendar = Calendar.get_calendar(ctx, self.groups, group_id)
 		# validate email address
 		if not is_email(email):
 			raise FriendlyError("Invalid email address", ctx, ctx.author, hidden=True)

--- a/modules/join/cog.py
+++ b/modules/join/cog.py
@@ -47,7 +47,7 @@ class JoinCog(commands.Cog):
 			),
 			create_option(
 				name="year",
-				description="Your year (an integer 1 to 4 inclusive)",
+				description="Your year",
 				option_type=SlashCommandOptionType.INTEGER,
 				required=True,
 				choices=[

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py==1.7.3
-discord-py-slash-command==1.2.2
+discord-py-slash-command==2.0.0
 python-dotenv==0.18.0
 googlesearch-python==1.0.1
 beautifulsoup4==4.9.3


### PR DESCRIPTION
Normally slash command options must have the same name as the function argument, but in some cases the argument has a different meaning since the choice name is not necessarily the same as the value.

Using connector allows us to name the option "class_name" but have the function argument be "group_id".