### PR TITLE
feat: Include the drive grant message in the email

### DIFF
--- a/modules/drive/cog.py
+++ b/modules/drive/cog.py
@@ -52,9 +52,21 @@ class DriveCog(commands.Cog):
                 interaction.user,
                 ephemeral=True,
             )
+        # create message
+        info_message = (
+            f"Thanks for helping keep the Drive up to date! ❤️\n\n"
+            f"You now have access to upload any tests, assignments, or other documents that may be useful to other students.\n\n"
+            f"Please read through the [Drive Guidelines]({config.drive_guidelines_url}) for more information on keeping the Drive organized."
+        )
+        if email.endswith("@g.jct.ac.il"):
+            info_message += (
+                "\n\n⚠️ Note: You are using a JCT email address, since it is unclear whether this email address is permanent, "
+                "we recommend that you use a personal email address instead to avoid files potentially being lost in the future."
+            )
+        email_message = info_message.replace("[Drive Guidelines]", "Drive Guidelines ")
         # add manager to Drive
         try:
-            self.service.add_manager(email)
+            self.service.add_manager(email=email, email_message=email_message)
         except Exception as e:
             raise FriendlyError(
                 "An error occurred while applying changes.",
@@ -65,18 +77,8 @@ class DriveCog(commands.Cog):
         # send success message
         embed = embed_success(
             title=f":office_worker: Successfully added {email} as an editor to the ESP Google Drive.",
-            description=(
-                f"Thanks for helping keep the Drive up to date! :heart:\n\n"
-                f"You now have access to upload any tests, assignments, or other documents that may be useful to other students.\n\n"
-                f"Please read through the [Drive Guidelines]({config.drive_guidelines_url}) for more information on keeping the Drive organized."
-            ),
+            description=info_message,
         )
-        if email.endswith("@g.jct.ac.il"):
-            embed.description = (
-                f"{embed.description}\n\n"
-                ":warning: Note: This is a JCT email address, since it is unclear whether this email address is permanent, "
-                "we recommend that you use a personal email address instead to avoid files potentially being lost in the future."
-            )
         await interaction.send(embed=embed, ephemeral=True)
 
 

--- a/modules/drive/drive_service.py
+++ b/modules/drive/drive_service.py
@@ -13,11 +13,12 @@ class DriveService:
         self.service = build("drive", "v3", credentials=self.creds)
         self.folder_id = folder_id
 
-    def add_manager(self, email: str) -> None:
+    def add_manager(self, email: str, email_message: str) -> None:
         """Gives write access to the Google Drive folder given an email address
 
         Args:
             email: The email address of the Google account to add
+            email_message: The message to send to the email address
 
         Raises:
             errors.HttpError: If an error occurs while creating the permission
@@ -30,7 +31,12 @@ class DriveService:
         }
         created_permission = (
             self.service.permissions()
-            .create(fileId=self.folder_id, body=rule, fields="emailAddress")
+            .create(
+                fileId=self.folder_id,
+                body=rule,
+                fields="emailAddress",
+                emailMessage=email_message,
+            )
             .execute()
         )
         assert created_permission["emailAddress"] == email


### PR DESCRIPTION
Sends an email with the thanks and guidelines link in addition to sending it in the embed.

Example of email:

![image](https://user-images.githubusercontent.com/20955511/222488616-0259c4e9-1d83-4c4a-af07-1d514ef4dd89.png)
